### PR TITLE
Fix map object being returned instead of an array of ints.

### DIFF
--- a/srclist_by_beam.py
+++ b/srclist_by_beam.py
@@ -72,7 +72,7 @@ if not 'DEC' in f[0].header.keys():
     sys.exit('Cannot find DEC in %s' % args.metafits)
 
 ##Gather the useful info
-delays=array(map(int,f[0].header['DELAYS'].split(',')))
+delays = array(f[0].header['DELAYS'].split(','), dtype=int)
 
 if len(where(delays == 32)[0]) == 16:
     print('---------------------------------------------------------------------')


### PR DESCRIPTION
Tested in conjunction with the 2to3 branch of https://github.com/MWATelescope/mwa_pb.  After running and diff-ing the output of running `srclist_by_beam.py` with various combinations of `--no_patch`, `--order=distance` and `--cutoff=5`, I think things are working as expected.  Let me know if there are other things I can test.